### PR TITLE
Rename classes to match their Qt Quick counterparts

### DIFF
--- a/examples/bookstore/widgets/Developer.qml
+++ b/examples/bookstore/widgets/Developer.qml
@@ -170,7 +170,7 @@ MainWindow {
                 source: "qrc:///qtquick/Shop.qml"
 
                 rootContext: QmlContext {
-                    DeclarativeContextProperty {
+                    QmlContextProperty {
                         name: "_store"
                         value: _store
                     }

--- a/examples/bookstore/widgets/Developer.qml
+++ b/examples/bookstore/widgets/Developer.qml
@@ -166,10 +166,10 @@ MainWindow {
         windowTitle: qsTr("Shop")
 
         VBoxLayout {
-            DeclarativeView {
+            QuickWidget {
                 source: "qrc:///qtquick/Shop.qml"
 
-                rootContext: DeclarativeContext {
+                rootContext: QmlContext {
                     DeclarativeContextProperty {
                         name: "_store"
                         value: _store

--- a/examples/declarativeview.qml
+++ b/examples/declarativeview.qml
@@ -60,7 +60,7 @@ Widget {
       VBoxLayout.stretch: 1
 
       rootContext: QmlContext {
-        DeclarativeContextProperty {
+        QmlContextProperty {
           name: "_textInput"
           value: textInput
         }

--- a/examples/declarativeview.qml
+++ b/examples/declarativeview.qml
@@ -54,12 +54,12 @@ Widget {
       }
     }
 
-    DeclarativeView {
+    QuickWidget {
       id: declarativeView
 
       VBoxLayout.stretch: 1
 
-      rootContext: DeclarativeContext {
+      rootContext: QmlContext {
         DeclarativeContextProperty {
           name: "_textInput"
           value: textInput

--- a/extensionplugin/extensionplugin_plugin.cpp
+++ b/extensionplugin/extensionplugin_plugin.cpp
@@ -104,7 +104,7 @@ void ExtensionpluginPlugin::registerTypes(const char *uri)
   qmlRegisterExtendedType<DeclarativeActionItem, DeclarativeObjectExtension>(uri, 1, 0, "ActionItem");
   qmlRegisterExtendedType<QButtonGroup, DeclarativeButtonGroupExtension>(uri, 1, 0, "ButtonGroup");
   qmlRegisterType<DeclarativeContextProperty>(uri, 1, 0, "DeclarativeContextProperty");
-  qmlRegisterType<DeclarativeQmlContext>(uri, 1, 0, "DeclarativeContext");
+  qmlRegisterType<DeclarativeQmlContext>(uri, 1, 0, "QmlContext");
   qmlRegisterExtendedType<QFileSystemModel, DeclarativeFileSystemModelExtension>(uri, 1, 0, "FileSystemModel");
   qmlRegisterType<DeclarativeIcon>(uri, 1, 0, "Icon");
   qmlRegisterType<QItemSelectionModel>();
@@ -130,7 +130,7 @@ void ExtensionpluginPlugin::registerTypes(const char *uri)
   qmlRegisterExtendedType<QComboBox, DeclarativeComboBoxExtension>(uri, 1, 0, "ComboBox");
   qmlRegisterExtendedType<QDateEdit, DeclarativeWidgetExtension>(uri, 1, 0, "DateEdit");
   qmlRegisterExtendedType<QDateTimeEdit, DeclarativeWidgetExtension>(uri, 1, 0, "DateTimeEdit");
-  qmlRegisterExtendedType<QQuickWidget, DeclarativeQuickWidgetExtension>(uri, 1, 0, "DeclarativeView");
+  qmlRegisterExtendedType<QQuickWidget, DeclarativeQuickWidgetExtension>(uri, 1, 0, "QuickWidget");
   qmlRegisterExtendedType<QDial, DeclarativeWidgetExtension>(uri, 1, 0, "Dial");
   qmlRegisterExtendedType<Dialog, DeclarativeWidgetExtension>(uri, 1, 0, "Dialog");
   qmlRegisterExtendedType<QDialogButtonBox, DeclarativeWidgetExtension>(uri, 1, 0, "DialogButtonBox");

--- a/extensionplugin/extensionplugin_plugin.cpp
+++ b/extensionplugin/extensionplugin_plugin.cpp
@@ -26,8 +26,6 @@
 #include "declarativecolordialog_p.h"
 #include "declarativecomboboxextension_p.h"
 #include "declarativecontainerwidgetextension_p.h"
-#include "declarativedeclarativecontext_p.h"
-#include "declarativedeclarativeviewextension_p.h"
 #include "declarativefiledialog_p.h"
 #include "declarativefilesystemmodelextension_p.h"
 #include "declarativefontdialog_p.h"
@@ -38,6 +36,8 @@
 #include "declarativeinputdialog_p.h"
 #include "declarativeitemviewextension_p.h"
 #include "declarativemessagebox_p.h"
+#include "declarativeqmlcontext_p.h"
+#include "declarativequickwidgetextension_p.h"
 #include "declarativeseparator_p.h"
 #include "declarativestackedlayout_p.h"
 #include "declarativestatusbar_p.h"
@@ -104,7 +104,7 @@ void ExtensionpluginPlugin::registerTypes(const char *uri)
   qmlRegisterExtendedType<DeclarativeActionItem, DeclarativeObjectExtension>(uri, 1, 0, "ActionItem");
   qmlRegisterExtendedType<QButtonGroup, DeclarativeButtonGroupExtension>(uri, 1, 0, "ButtonGroup");
   qmlRegisterType<DeclarativeContextProperty>(uri, 1, 0, "DeclarativeContextProperty");
-  qmlRegisterType<DeclarativeDeclarativeContext>(uri, 1, 0, "DeclarativeContext");
+  qmlRegisterType<DeclarativeQmlContext>(uri, 1, 0, "DeclarativeContext");
   qmlRegisterExtendedType<QFileSystemModel, DeclarativeFileSystemModelExtension>(uri, 1, 0, "FileSystemModel");
   qmlRegisterType<DeclarativeIcon>(uri, 1, 0, "Icon");
   qmlRegisterType<QItemSelectionModel>();
@@ -130,7 +130,7 @@ void ExtensionpluginPlugin::registerTypes(const char *uri)
   qmlRegisterExtendedType<QComboBox, DeclarativeComboBoxExtension>(uri, 1, 0, "ComboBox");
   qmlRegisterExtendedType<QDateEdit, DeclarativeWidgetExtension>(uri, 1, 0, "DateEdit");
   qmlRegisterExtendedType<QDateTimeEdit, DeclarativeWidgetExtension>(uri, 1, 0, "DateTimeEdit");
-  qmlRegisterExtendedType<QQuickWidget, DeclarativeDeclarativeViewExtension>(uri, 1, 0, "DeclarativeView");
+  qmlRegisterExtendedType<QQuickWidget, DeclarativeQuickWidgetExtension>(uri, 1, 0, "DeclarativeView");
   qmlRegisterExtendedType<QDial, DeclarativeWidgetExtension>(uri, 1, 0, "Dial");
   qmlRegisterExtendedType<Dialog, DeclarativeWidgetExtension>(uri, 1, 0, "Dialog");
   qmlRegisterExtendedType<QDialogButtonBox, DeclarativeWidgetExtension>(uri, 1, 0, "DialogButtonBox");

--- a/extensionplugin/extensionplugin_plugin.cpp
+++ b/extensionplugin/extensionplugin_plugin.cpp
@@ -103,7 +103,7 @@ void ExtensionpluginPlugin::registerTypes(const char *uri)
   qmlRegisterExtendedType<DeclarativeAction, DeclarativeObjectExtension>(uri, 1, 0, "Action");
   qmlRegisterExtendedType<DeclarativeActionItem, DeclarativeObjectExtension>(uri, 1, 0, "ActionItem");
   qmlRegisterExtendedType<QButtonGroup, DeclarativeButtonGroupExtension>(uri, 1, 0, "ButtonGroup");
-  qmlRegisterType<DeclarativeContextProperty>(uri, 1, 0, "DeclarativeContextProperty");
+  qmlRegisterType<DeclarativeQmlContextProperty>(uri, 1, 0, "QmlContextProperty");
   qmlRegisterType<DeclarativeQmlContext>(uri, 1, 0, "QmlContext");
   qmlRegisterExtendedType<QFileSystemModel, DeclarativeFileSystemModelExtension>(uri, 1, 0, "FileSystemModel");
   qmlRegisterType<DeclarativeIcon>(uri, 1, 0, "Icon");

--- a/lib/declarativeqmlcontext.cpp
+++ b/lib/declarativeqmlcontext.cpp
@@ -53,7 +53,7 @@ void DeclarativeQmlContext::createProxiedObject() const
 
 void DeclarativeQmlContext::dataAppend(QObject *object)
 {
-  DeclarativeContextProperty *contextProperty = qobject_cast<DeclarativeContextProperty*>(object);
+  DeclarativeQmlContextProperty *contextProperty = qobject_cast<DeclarativeQmlContextProperty*>(object);
   if (contextProperty) {
     if (!m_proxiedObject)
       createProxiedObject();

--- a/lib/declarativeqmlcontext.cpp
+++ b/lib/declarativeqmlcontext.cpp
@@ -48,7 +48,7 @@ void DeclarativeQmlContext::createProxiedObject() const
     }
   }
 
-  qmlInfo(this) << "Cannot create DeclarativeContext, parent is neither DeclarativeView nor DeclarativeContext";
+  qmlInfo(this) << "Cannot create DeclarativeContext, parent is neither QuickWidget nor DeclarativeContext";
 }
 
 void DeclarativeQmlContext::dataAppend(QObject *object)

--- a/lib/declarativeqmlcontext.cpp
+++ b/lib/declarativeqmlcontext.cpp
@@ -18,16 +18,16 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-#include "declarativedeclarativecontext_p.h"
+#include "declarativeqmlcontext_p.h"
 
 #include <QQuickWidget>
 
-DeclarativeDeclarativeContext::DeclarativeDeclarativeContext(QObject *parent)
+DeclarativeQmlContext::DeclarativeQmlContext(QObject *parent)
   : DeclarativeObjectProxy<DeclarativeContext>(parent)
 {
 }
 
-void DeclarativeDeclarativeContext::createProxiedObject() const
+void DeclarativeQmlContext::createProxiedObject() const
 {
   AbstractDeclarativeObject *declarativeParent = dynamic_cast<AbstractDeclarativeObject*>(parent());
   if (declarativeParent) {
@@ -51,7 +51,7 @@ void DeclarativeDeclarativeContext::createProxiedObject() const
   qmlInfo(this) << "Cannot create DeclarativeContext, parent is neither DeclarativeView nor DeclarativeContext";
 }
 
-void DeclarativeDeclarativeContext::dataAppend(QObject *object)
+void DeclarativeQmlContext::dataAppend(QObject *object)
 {
   DeclarativeContextProperty *contextProperty = qobject_cast<DeclarativeContextProperty*>(object);
   if (contextProperty) {
@@ -64,4 +64,4 @@ void DeclarativeDeclarativeContext::dataAppend(QObject *object)
   DeclarativeObjectProxy<DeclarativeContext>::dataAppend(object);
 }
 
-CUSTOM_METAOBJECT(DeclarativeDeclarativeContext, DeclarativeContext)
+CUSTOM_METAOBJECT(DeclarativeQmlContext, DeclarativeContext)

--- a/lib/declarativeqmlcontext_p.h
+++ b/lib/declarativeqmlcontext_p.h
@@ -25,12 +25,12 @@
 
 #include "objectadaptors_p.h"
 
-class DeclarativeDeclarativeContext : public DeclarativeObjectProxy<DeclarativeContext>
+class DeclarativeQmlContext : public DeclarativeObjectProxy<DeclarativeContext>
 {
   DECLARATIVE_OBJECT
 
   public:
-    explicit DeclarativeDeclarativeContext(QObject *parent = 0);
+    explicit DeclarativeQmlContext(QObject *parent = 0);
 
   protected:
     void createProxiedObject() const;

--- a/lib/declarativequickwidgetextension.cpp
+++ b/lib/declarativequickwidgetextension.cpp
@@ -18,22 +18,22 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-#include "declarativedeclarativeviewextension_p.h"
+#include "declarativequickwidgetextension_p.h"
 
-#include "declarativedeclarativecontext_p.h"
+#include "declarativeqmlcontext_p.h"
 
 #include <QQuickWidget>
 
-DeclarativeDeclarativeViewExtension::DeclarativeDeclarativeViewExtension(QObject *parent)
+DeclarativeQuickWidgetExtension::DeclarativeQuickWidgetExtension(QObject *parent)
   : DeclarativeWidgetExtension(parent)
 {
 }
 
-DeclarativeDeclarativeViewExtension::~DeclarativeDeclarativeViewExtension()
+DeclarativeQuickWidgetExtension::~DeclarativeQuickWidgetExtension()
 {
 }
 
-QQuickWidget *DeclarativeDeclarativeViewExtension::extendedDeclarativeView() const
+QQuickWidget *DeclarativeQuickWidgetExtension::extendedDeclarativeView() const
 {
   QQuickWidget *declarativeView = qobject_cast<QQuickWidget*>(extendedWidget());
   Q_ASSERT(declarativeView);
@@ -41,7 +41,7 @@ QQuickWidget *DeclarativeDeclarativeViewExtension::extendedDeclarativeView() con
   return declarativeView;
 }
 
-void DeclarativeDeclarativeViewExtension::setDeclarativeRootContext(QObject *context)
+void DeclarativeQuickWidgetExtension::setDeclarativeRootContext(QObject *context)
 {
   DeclarativeContext *declarativeContext = dynamic_cast<DeclarativeContext*>(context);
   if (!declarativeContext) {
@@ -66,7 +66,7 @@ void DeclarativeDeclarativeViewExtension::setDeclarativeRootContext(QObject *con
   emit declarativeRootContextChanged();
 }
 
-QObject *DeclarativeDeclarativeViewExtension::declarativeRootContext() const
+QObject *DeclarativeQuickWidgetExtension::declarativeRootContext() const
 {
   return m_rootContext;
 }

--- a/lib/declarativequickwidgetextension.cpp
+++ b/lib/declarativequickwidgetextension.cpp
@@ -33,7 +33,7 @@ DeclarativeQuickWidgetExtension::~DeclarativeQuickWidgetExtension()
 {
 }
 
-QQuickWidget *DeclarativeQuickWidgetExtension::extendedDeclarativeView() const
+QQuickWidget *DeclarativeQuickWidgetExtension::extendedQuickWidget() const
 {
   QQuickWidget *declarativeView = qobject_cast<QQuickWidget*>(extendedWidget());
   Q_ASSERT(declarativeView);

--- a/lib/declarativequickwidgetextension_p.h
+++ b/lib/declarativequickwidgetextension_p.h
@@ -44,7 +44,7 @@ class DeclarativeQuickWidgetExtension : public DeclarativeWidgetExtension
     explicit DeclarativeQuickWidgetExtension(QObject *parent = 0);
     ~DeclarativeQuickWidgetExtension();
 
-    QQuickWidget *extendedDeclarativeView() const;
+    QQuickWidget *extendedQuickWidget() const;
 
     void setDeclarativeRootContext(QObject *context);
     QObject *declarativeRootContext() const;

--- a/lib/declarativequickwidgetextension_p.h
+++ b/lib/declarativequickwidgetextension_p.h
@@ -28,7 +28,7 @@
 class DeclarativeContext;
 class QQuickWidget;
 
-class DeclarativeDeclarativeViewExtension : public DeclarativeWidgetExtension
+class DeclarativeQuickWidgetExtension : public DeclarativeWidgetExtension
 {
   Q_OBJECT
 
@@ -41,8 +41,8 @@ class DeclarativeDeclarativeViewExtension : public DeclarativeWidgetExtension
   Q_CLASSINFO("DefaultProperty", "data")
 
   public:
-    explicit DeclarativeDeclarativeViewExtension(QObject *parent = 0);
-    ~DeclarativeDeclarativeViewExtension();
+    explicit DeclarativeQuickWidgetExtension(QObject *parent = 0);
+    ~DeclarativeQuickWidgetExtension();
 
     QQuickWidget *extendedDeclarativeView() const;
 

--- a/lib/declarativewidgetsdocument.cpp
+++ b/lib/declarativewidgetsdocument.cpp
@@ -27,8 +27,6 @@
 #include "declarativecolordialog_p.h"
 #include "declarativecomboboxextension_p.h"
 #include "declarativecontainerwidgetextension_p.h"
-#include "declarativedeclarativecontext_p.h"
-#include "declarativedeclarativeviewextension_p.h"
 #include "declarativefiledialog_p.h"
 #include "declarativefilesystemmodelextension_p.h"
 #include "declarativefontdialog_p.h"
@@ -43,6 +41,8 @@
 #include "declarativeloaderwidget_p.h"
 #include "declarativemessagebox_p.h"
 #include "declarativepixmap_p.h"
+#include "declarativeqmlcontext_p.h"
+#include "declarativequickwidgetextension_p.h"
 #include "declarativeseparator_p.h"
 #include "declarativespaceritem_p.h"
 #include "declarativestackedlayout_p.h"
@@ -129,7 +129,7 @@ DeclarativeWidgetsDocument::DeclarativeWidgetsDocument(const QUrl &url, QObject 
   qmlRegisterExtendedType<DeclarativeActionItem, DeclarativeObjectExtension>("QtWidgets", 1, 0, "ActionItem");
   qmlRegisterExtendedType<QButtonGroup, DeclarativeButtonGroupExtension>("QtWidgets", 1, 0, "ButtonGroup");
   qmlRegisterType<DeclarativeContextProperty>("QtWidgets", 1, 0, "DeclarativeContextProperty");
-  qmlRegisterType<DeclarativeDeclarativeContext>("QtWidgets", 1, 0, "DeclarativeContext");
+  qmlRegisterType<DeclarativeQmlContext>("QtWidgets", 1, 0, "DeclarativeContext");
   qmlRegisterExtendedType<QFileSystemModel, DeclarativeFileSystemModelExtension>("QtWidgets", 1, 0, "FileSystemModel");
   qmlRegisterType<DeclarativeIcon>("QtWidgets", 1, 0, "Icon");
   qmlRegisterType<QItemSelectionModel>();
@@ -158,7 +158,7 @@ DeclarativeWidgetsDocument::DeclarativeWidgetsDocument(const QUrl &url, QObject 
   qmlRegisterExtendedType<QComboBox, DeclarativeComboBoxExtension>("QtWidgets", 1, 0, "ComboBox");
   qmlRegisterExtendedType<QDateEdit, DeclarativeWidgetExtension>("QtWidgets", 1, 0, "DateEdit");
   qmlRegisterExtendedType<QDateTimeEdit, DeclarativeWidgetExtension>("QtWidgets", 1, 0, "DateTimeEdit");
-  qmlRegisterExtendedType<QQuickWidget, DeclarativeDeclarativeViewExtension>("QtWidgets", 1, 0, "DeclarativeView");
+  qmlRegisterExtendedType<QQuickWidget, DeclarativeQuickWidgetExtension>("QtWidgets", 1, 0, "DeclarativeView");
   qmlRegisterExtendedType<QDial, DeclarativeWidgetExtension>("QtWidgets", 1, 0, "Dial");
   qmlRegisterExtendedType<Dialog, DeclarativeWidgetExtension>("QtWidgets", 1, 0, "Dialog");
   qmlRegisterExtendedType<QDialogButtonBox, DeclarativeWidgetExtension>("QtWidgets", 1, 0, "DialogButtonBox");

--- a/lib/declarativewidgetsdocument.cpp
+++ b/lib/declarativewidgetsdocument.cpp
@@ -129,7 +129,7 @@ DeclarativeWidgetsDocument::DeclarativeWidgetsDocument(const QUrl &url, QObject 
   qmlRegisterExtendedType<DeclarativeActionItem, DeclarativeObjectExtension>("QtWidgets", 1, 0, "ActionItem");
   qmlRegisterExtendedType<QButtonGroup, DeclarativeButtonGroupExtension>("QtWidgets", 1, 0, "ButtonGroup");
   qmlRegisterType<DeclarativeContextProperty>("QtWidgets", 1, 0, "DeclarativeContextProperty");
-  qmlRegisterType<DeclarativeQmlContext>("QtWidgets", 1, 0, "DeclarativeContext");
+  qmlRegisterType<DeclarativeQmlContext>("QtWidgets", 1, 0, "QmlContext");
   qmlRegisterExtendedType<QFileSystemModel, DeclarativeFileSystemModelExtension>("QtWidgets", 1, 0, "FileSystemModel");
   qmlRegisterType<DeclarativeIcon>("QtWidgets", 1, 0, "Icon");
   qmlRegisterType<QItemSelectionModel>();
@@ -158,7 +158,7 @@ DeclarativeWidgetsDocument::DeclarativeWidgetsDocument(const QUrl &url, QObject 
   qmlRegisterExtendedType<QComboBox, DeclarativeComboBoxExtension>("QtWidgets", 1, 0, "ComboBox");
   qmlRegisterExtendedType<QDateEdit, DeclarativeWidgetExtension>("QtWidgets", 1, 0, "DateEdit");
   qmlRegisterExtendedType<QDateTimeEdit, DeclarativeWidgetExtension>("QtWidgets", 1, 0, "DateTimeEdit");
-  qmlRegisterExtendedType<QQuickWidget, DeclarativeQuickWidgetExtension>("QtWidgets", 1, 0, "DeclarativeView");
+  qmlRegisterExtendedType<QQuickWidget, DeclarativeQuickWidgetExtension>("QtWidgets", 1, 0, "QuickWidget");
   qmlRegisterExtendedType<QDial, DeclarativeWidgetExtension>("QtWidgets", 1, 0, "Dial");
   qmlRegisterExtendedType<Dialog, DeclarativeWidgetExtension>("QtWidgets", 1, 0, "Dialog");
   qmlRegisterExtendedType<QDialogButtonBox, DeclarativeWidgetExtension>("QtWidgets", 1, 0, "DialogButtonBox");

--- a/lib/declarativewidgetsdocument.cpp
+++ b/lib/declarativewidgetsdocument.cpp
@@ -128,7 +128,7 @@ DeclarativeWidgetsDocument::DeclarativeWidgetsDocument(const QUrl &url, QObject 
   qmlRegisterExtendedType<DeclarativeAction, DeclarativeObjectExtension>("QtWidgets", 1, 0, "Action");
   qmlRegisterExtendedType<DeclarativeActionItem, DeclarativeObjectExtension>("QtWidgets", 1, 0, "ActionItem");
   qmlRegisterExtendedType<QButtonGroup, DeclarativeButtonGroupExtension>("QtWidgets", 1, 0, "ButtonGroup");
-  qmlRegisterType<DeclarativeContextProperty>("QtWidgets", 1, 0, "DeclarativeContextProperty");
+  qmlRegisterType<DeclarativeQmlContextProperty>("QtWidgets", 1, 0, "QmlContextProperty");
   qmlRegisterType<DeclarativeQmlContext>("QtWidgets", 1, 0, "QmlContext");
   qmlRegisterExtendedType<QFileSystemModel, DeclarativeFileSystemModelExtension>("QtWidgets", 1, 0, "FileSystemModel");
   qmlRegisterType<DeclarativeIcon>("QtWidgets", 1, 0, "Icon");

--- a/lib/lib.pro
+++ b/lib/lib.pro
@@ -17,8 +17,6 @@ HEADERS = \
   declarativecolordialog_p.h \
   declarativecomboboxextension_p.h \
   declarativecontainerwidgetextension_p.h \
-  declarativedeclarativecontext_p.h \
-  declarativedeclarativeviewextension_p.h \
   declarativefiledialog_p.h \
   declarativefilesystemmodelextension_p.h \
   declarativefontdialog_p.h \
@@ -33,6 +31,8 @@ HEADERS = \
   declarativeobjectextension.h \
   declarativeobjectproxy_p.h \
   declarativepixmap_p.h \
+  declarativeqmlcontext_p.h \
+  declarativequickwidgetextension_p.h \
   declarativeseparator_p.h \
   declarativestackedlayout_p.h \
   declarativestatusbar_p.h \
@@ -71,8 +71,6 @@ SOURCES = \
   declarativebuttongroupextension.cpp \
   declarativecolordialog.cpp \
   declarativecomboboxextension.cpp \
-  declarativedeclarativecontext.cpp \
-  declarativedeclarativeviewextension.cpp \
   declarativefiledialog.cpp \
   declarativefilesystemmodelextension.cpp \
   declarativefontdialog.cpp \
@@ -86,6 +84,8 @@ SOURCES = \
   declarativemessagebox.cpp \
   declarativeobjectextension.cpp \
   declarativepixmap.cpp \
+  declarativeqmlcontext.cpp \
+  declarativequickwidgetextension.cpp \
   declarativeseparator.cpp \
   declarativestackedlayout.cpp \
   declarativestatusbar.cpp \

--- a/lib/objectadaptors.cpp
+++ b/lib/objectadaptors.cpp
@@ -93,13 +93,13 @@ DeclarativeContext::DeclarativeContext(QObject *parent)
 {
 }
 
-// DeclarativeContextProperty
-DeclarativeContextProperty::DeclarativeContextProperty(QObject *parent)
+// DeclarativeQmlContextProperty
+DeclarativeQmlContextProperty::DeclarativeQmlContextProperty(QObject *parent)
   : QObject(parent)
 {
 }
 
-void DeclarativeContextProperty::setName(const QString &name)
+void DeclarativeQmlContextProperty::setName(const QString &name)
 {
   if (name == m_name)
     return;
@@ -110,12 +110,12 @@ void DeclarativeContextProperty::setName(const QString &name)
   setOnContext();
 }
 
-QString DeclarativeContextProperty::name() const
+QString DeclarativeQmlContextProperty::name() const
 {
   return m_name;
 }
 
-void DeclarativeContextProperty::setValue(const QVariant &value)
+void DeclarativeQmlContextProperty::setValue(const QVariant &value)
 {
   if (value == m_value)
     return;
@@ -126,23 +126,23 @@ void DeclarativeContextProperty::setValue(const QVariant &value)
   setOnContext();
 }
 
-QVariant DeclarativeContextProperty::value() const
+QVariant DeclarativeQmlContextProperty::value() const
 {
   return m_value;
 }
 
-bool DeclarativeContextProperty::isValid() const
+bool DeclarativeQmlContextProperty::isValid() const
 {
   return !m_name.isEmpty() && m_value.isValid() && !m_value.isNull();
 }
 
-void DeclarativeContextProperty::setContext(DeclarativeContext *context)
+void DeclarativeQmlContextProperty::setContext(DeclarativeContext *context)
 {
   m_context = QPointer<DeclarativeContext>(context);
   setOnContext();
 }
 
-void DeclarativeContextProperty::setOnContext()
+void DeclarativeQmlContextProperty::setOnContext()
 {
   if (!isValid() || !m_context)
     return;

--- a/lib/objectadaptors_p.h
+++ b/lib/objectadaptors_p.h
@@ -56,14 +56,14 @@ class DeclarativeContext : public QObject
 
 Q_DECLARE_METATYPE(DeclarativeContext*)
 
-class DeclarativeContextProperty : public QObject
+class DeclarativeQmlContextProperty : public QObject
 {
   Q_OBJECT
   Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
   Q_PROPERTY(QVariant value READ value WRITE setValue NOTIFY valueChanged)
 
   public:
-    explicit DeclarativeContextProperty(QObject *parent = 0);
+    explicit DeclarativeQmlContextProperty(QObject *parent = 0);
 
     void setName(const QString &name);
     QString name() const;

--- a/tests/tst_declarativeview.cpp
+++ b/tests/tst_declarativeview.cpp
@@ -41,7 +41,7 @@ private slots:
 
 tst_DeclarativeView::tst_DeclarativeView()
 {
-    qmlRegisterType<DeclarativeContextProperty>("Qt.Widgets", 1, 0, "DeclarativeContextProperty");
+    qmlRegisterType<DeclarativeQmlContextProperty>("Qt.Widgets", 1, 0, "QmlContextProperty");
     qmlRegisterType<DeclarativeQmlContext>("Qt.Widgets", 1, 0, "QmlContext");
 
     qmlRegisterExtendedType<QQuickWidget, DeclarativeQuickWidgetExtension>("Qt.Widgets", 1, 0, "QuickWidget");
@@ -94,7 +94,7 @@ void tst_DeclarativeView::instantiateQQuickWidgetWithContextProperty()
                       "QuickWidget { \n"
                       "    source: \"qrc:///rectangle-context.qml\"\n"
                       "    rootContext: QmlContext {\n"
-                      "        DeclarativeContextProperty {\n"
+                      "        QmlContextProperty {\n"
                       "            name: \"_colour\"\n"
                       "            value: \"lightblue\"\n"
                       "        }\n"

--- a/tests/tst_declarativeview.cpp
+++ b/tests/tst_declarativeview.cpp
@@ -24,8 +24,8 @@
 #include <QQuickItem>
 #include <QQuickWidget>
 
-#include "declarativedeclarativecontext_p.h"
-#include "declarativedeclarativeviewextension_p.h"
+#include "declarativeqmlcontext_p.h"
+#include "declarativequickwidgetextension_p.h"
 
 class tst_DeclarativeView : public QObject
 {
@@ -42,9 +42,9 @@ private slots:
 tst_DeclarativeView::tst_DeclarativeView()
 {
     qmlRegisterType<DeclarativeContextProperty>("Qt.Widgets", 1, 0, "DeclarativeContextProperty");
-    qmlRegisterType<DeclarativeDeclarativeContext>("Qt.Widgets", 1, 0, "DeclarativeContext");
+    qmlRegisterType<DeclarativeQmlContext>("Qt.Widgets", 1, 0, "DeclarativeContext");
 
-    qmlRegisterExtendedType<QQuickWidget, DeclarativeDeclarativeViewExtension>("Qt.Widgets", 1, 0, "DeclarativeView");
+    qmlRegisterExtendedType<QQuickWidget, DeclarativeQuickWidgetExtension>("Qt.Widgets", 1, 0, "DeclarativeView");
 }
 
 void tst_DeclarativeView::instantiateQQuickWidget()

--- a/tests/tst_declarativeview.cpp
+++ b/tests/tst_declarativeview.cpp
@@ -42,9 +42,9 @@ private slots:
 tst_DeclarativeView::tst_DeclarativeView()
 {
     qmlRegisterType<DeclarativeContextProperty>("Qt.Widgets", 1, 0, "DeclarativeContextProperty");
-    qmlRegisterType<DeclarativeQmlContext>("Qt.Widgets", 1, 0, "DeclarativeContext");
+    qmlRegisterType<DeclarativeQmlContext>("Qt.Widgets", 1, 0, "QmlContext");
 
-    qmlRegisterExtendedType<QQuickWidget, DeclarativeQuickWidgetExtension>("Qt.Widgets", 1, 0, "DeclarativeView");
+    qmlRegisterExtendedType<QQuickWidget, DeclarativeQuickWidgetExtension>("Qt.Widgets", 1, 0, "QuickWidget");
 }
 
 void tst_DeclarativeView::instantiateQQuickWidget()
@@ -52,7 +52,7 @@ void tst_DeclarativeView::instantiateQQuickWidget()
     QQmlEngine engine;
     QQmlComponent component(&engine);
     component.setData("import Qt.Widgets 1.0;\n"
-                      "DeclarativeView { \n"
+                      "QuickWidget { \n"
                       "    source: \"qrc:///rectangle.qml\"\n"
                       "}", QUrl());
     QScopedPointer<QObject> object(component.create());
@@ -70,9 +70,9 @@ void tst_DeclarativeView::instantiateQQuickWidgetWithContext()
     QQmlEngine engine;
     QQmlComponent component(&engine);
     component.setData("import Qt.Widgets 1.0;\n"
-                      "DeclarativeView { \n"
+                      "QuickWidget { \n"
                       "    source: \"qrc:///rectangle.qml\"\n"
-                      "    rootContext: DeclarativeContext { }"
+                      "    rootContext: QmlContext { }"
                       "}", QUrl());
     {
         QScopedPointer<QObject> object(component.create());
@@ -91,9 +91,9 @@ void tst_DeclarativeView::instantiateQQuickWidgetWithContextProperty()
     QQmlEngine engine;
     QQmlComponent component(&engine);
     component.setData("import Qt.Widgets 1.0;\n"
-                      "DeclarativeView { \n"
+                      "QuickWidget { \n"
                       "    source: \"qrc:///rectangle-context.qml\"\n"
-                      "    rootContext: DeclarativeContext {\n"
+                      "    rootContext: QmlContext {\n"
                       "        DeclarativeContextProperty {\n"
                       "            name: \"_colour\"\n"
                       "            value: \"lightblue\"\n"


### PR DESCRIPTION
DeclarativeDeclarativeContext -> DeclarativeQmlContext
DeclarativeDeclarativeViewExtension -> DeclarativeQuickWidgetExtension