### PR TITLE
Add support for Pixmap

### DIFF
--- a/src/declarativewidgets_plugin.cpp
+++ b/src/declarativewidgets_plugin.cpp
@@ -48,6 +48,7 @@
 #include "declarativeline_p.h"
 #include "declarativeloaderwidget_p.h"
 #include "declarativemessagebox_p.h"
+#include "declarativepixmap_p.h"
 #include "declarativeqmlcontext_p.h"
 #include "declarativequickwidgetextension_p.h"
 #include "declarativeseparator_p.h"
@@ -68,7 +69,6 @@
 #include "scrollareawidgetcontainer_p.h"
 #include "stackedwidgetwidgetcontainer_p.h"
 #include "toolbarwidgetcontainer_p.h"
-#include "declarativepixmap_p.h"
 
 #include <QButtonGroup>
 #include <QCalendarWidget>

--- a/src/declarativewidgets_plugin.cpp
+++ b/src/declarativewidgets_plugin.cpp
@@ -68,6 +68,7 @@
 #include "scrollareawidgetcontainer_p.h"
 #include "stackedwidgetwidgetcontainer_p.h"
 #include "toolbarwidgetcontainer_p.h"
+#include "declarativepixmap_p.h"
 
 #include <QButtonGroup>
 #include <QCalendarWidget>
@@ -139,6 +140,7 @@ void ExtensionpluginPlugin::registerTypes(const char *uri)
   qmlRegisterType<DeclarativeIcon>(uri, 1, 0, "Icon");
   qmlRegisterExtendedType<DeclarativeSeparator, DeclarativeObjectExtension>(uri, 1, 0, "Separator");
   qmlRegisterType<DeclarativeTabStops>("QtWidgets", 1, 0, "TabStops");
+  qmlRegisterType<DeclarativePixmap>(uri, 1, 0, "Pixmap");
 
   // layouts
   qmlRegisterExtendedType<DeclarativeFormLayout, DeclarativeFormLayoutExtension>(uri, 1, 0, "FormLayout");


### PR DESCRIPTION
There already existed a DeclarativePixmap type which was not registered.
This commit registers the type for use with QML.