### PR TITLE
 Add QSizePolicy extension

### DIFF
--- a/src/declarativesizepolicy.cpp
+++ b/src/declarativesizepolicy.cpp
@@ -1,0 +1,182 @@
+#include "declarativesizepolicy_p.h"
+
+#include <QWidget>
+
+DeclarativeSizePolicy::DeclarativeSizePolicy(QWidget *extendedWidget, QObject *parent)
+    : QObject(parent)
+    , m_extendedWidget(extendedWidget)
+{
+    Q_ASSERT(m_extendedWidget);
+}
+
+DeclarativeSizePolicy::ControlType DeclarativeSizePolicy::controlType() const
+{
+    Q_ASSERT(m_extendedWidget);
+
+    return static_cast<DeclarativeSizePolicy::ControlType>(m_extendedWidget->sizePolicy().controlType());
+}
+
+DeclarativeSizePolicy::Policy DeclarativeSizePolicy::horizontalPolicy() const
+{
+    Q_ASSERT(m_extendedWidget);
+
+    return static_cast<DeclarativeSizePolicy::Policy>(m_extendedWidget->sizePolicy().horizontalPolicy());
+}
+
+DeclarativeSizePolicy::Policy DeclarativeSizePolicy::verticalPolicy() const
+{
+    Q_ASSERT(m_extendedWidget);
+
+    return static_cast<DeclarativeSizePolicy::Policy>(m_extendedWidget->sizePolicy().verticalPolicy());
+}
+
+Qt::Orientations DeclarativeSizePolicy::expandingDirections() const
+{
+    Q_ASSERT(m_extendedWidget);
+
+    return m_extendedWidget->sizePolicy().expandingDirections();
+}
+
+bool DeclarativeSizePolicy::hasHeightForWidth() const
+{
+    Q_ASSERT(m_extendedWidget);
+
+    return m_extendedWidget->sizePolicy().hasHeightForWidth();
+}
+
+bool DeclarativeSizePolicy::hasWidthForHeight() const
+{
+    Q_ASSERT(m_extendedWidget);
+
+    return m_extendedWidget->sizePolicy().hasWidthForHeight();
+}
+
+int DeclarativeSizePolicy::horizontalStretch() const
+{
+    Q_ASSERT(m_extendedWidget);
+
+    return m_extendedWidget->sizePolicy().horizontalStretch();
+}
+
+int DeclarativeSizePolicy::verticalStretch() const
+{
+
+    Q_ASSERT(m_extendedWidget);
+
+    return m_extendedWidget->sizePolicy().verticalStretch();
+}
+
+bool DeclarativeSizePolicy::retainSizeWhenHidden() const
+{
+    Q_ASSERT(m_extendedWidget);
+
+    return m_extendedWidget->sizePolicy().retainSizeWhenHidden();
+}
+
+void DeclarativeSizePolicy::setControlType(DeclarativeSizePolicy::ControlType controlType)
+{
+    Q_ASSERT(m_extendedWidget);
+
+    QSizePolicy policy = m_extendedWidget->sizePolicy();
+    if (policy.controlType() == static_cast<QSizePolicy::ControlType>(controlType))
+        return;
+    policy.setControlType(static_cast<QSizePolicy::ControlType>(controlType));
+    m_extendedWidget->setSizePolicy(policy);
+    emit controlTypeChanged(controlType);
+}
+
+void DeclarativeSizePolicy::setHorizontalPolicy(DeclarativeSizePolicy::Policy horizontalPolicy)
+{
+    Q_ASSERT(m_extendedWidget);
+
+    QSizePolicy policy = m_extendedWidget->sizePolicy();
+    if (policy.horizontalPolicy() == static_cast<QSizePolicy::Policy>(horizontalPolicy))
+        return;
+
+    const Qt::Orientations oldExpandingDirections = policy.expandingDirections();
+    policy.setHorizontalPolicy(static_cast<QSizePolicy::Policy>(horizontalPolicy));
+    const Qt::Orientations newExpandingDirections = policy.expandingDirections();
+    m_extendedWidget->setSizePolicy(policy);
+
+    emit horizontalPolicyChanged(horizontalPolicy);
+    if (newExpandingDirections != oldExpandingDirections)
+        emit expandingDirectionsChanged(newExpandingDirections);
+}
+
+void DeclarativeSizePolicy::setVerticalPolicy(DeclarativeSizePolicy::Policy verticalPolicy)
+{
+    Q_ASSERT(m_extendedWidget);
+
+    QSizePolicy policy = m_extendedWidget->sizePolicy();
+    if (policy.verticalPolicy() == static_cast<QSizePolicy::Policy>(verticalPolicy))
+        return;
+
+    const Qt::Orientations oldExpandingDirections = policy.expandingDirections();
+    policy.setVerticalPolicy(static_cast<QSizePolicy::Policy>(verticalPolicy));
+    const Qt::Orientations newExpandingDirections = policy.expandingDirections();
+    m_extendedWidget->setSizePolicy(policy);
+
+    emit verticalPolicyChanged(verticalPolicy);
+    if (newExpandingDirections != oldExpandingDirections)
+        emit expandingDirectionsChanged(newExpandingDirections);
+}
+
+void DeclarativeSizePolicy::setHeightForWidth(bool heightForWidth)
+{
+    Q_ASSERT(m_extendedWidget);
+
+    QSizePolicy policy = m_extendedWidget->sizePolicy();
+    if (policy.hasHeightForWidth() == heightForWidth)
+        return;
+    policy.setHeightForWidth(heightForWidth);
+    m_extendedWidget->setSizePolicy(policy);
+    emit hasHeightForWidthChanged(heightForWidth);
+}
+
+void DeclarativeSizePolicy::setWidthForHeight(bool widthForHeight)
+{
+    Q_ASSERT(m_extendedWidget);
+
+    QSizePolicy policy = m_extendedWidget->sizePolicy();
+    if (policy.hasWidthForHeight() == widthForHeight)
+        return;
+    policy.setWidthForHeight(widthForHeight);
+    m_extendedWidget->setSizePolicy(policy);
+    emit hasWidthForHeightChanged(widthForHeight);
+}
+
+void DeclarativeSizePolicy::setHorizontalStretch(int horizontalStretch)
+{
+    Q_ASSERT(m_extendedWidget);
+
+    QSizePolicy policy = m_extendedWidget->sizePolicy();
+    if (policy.horizontalStretch() == horizontalStretch)
+        return;
+    policy.setHorizontalStretch(horizontalStretch);
+    m_extendedWidget->setSizePolicy(policy);
+    emit horizontalStretchChanged(horizontalStretch);
+}
+
+void DeclarativeSizePolicy::setVerticalStretch(int verticalStretch)
+{
+    Q_ASSERT(m_extendedWidget);
+
+    QSizePolicy policy = m_extendedWidget->sizePolicy();
+    if (policy.verticalStretch() == verticalStretch)
+        return;
+    policy.setVerticalStretch(verticalStretch);
+    m_extendedWidget->setSizePolicy(policy);
+    emit verticalStretchChanged(verticalStretch);
+}
+
+void DeclarativeSizePolicy::setRetainSizeWhenHidden(bool retainSizeWhenHidden)
+{
+    Q_ASSERT(m_extendedWidget);
+
+    QSizePolicy policy = m_extendedWidget->sizePolicy();
+    if (policy.retainSizeWhenHidden() == retainSizeWhenHidden)
+        return;
+    policy.setRetainSizeWhenHidden(retainSizeWhenHidden);
+    m_extendedWidget->setSizePolicy(policy);
+    emit retainSizeWhenHiddenChanged(retainSizeWhenHidden);
+}

--- a/src/declarativesizepolicy_p.h
+++ b/src/declarativesizepolicy_p.h
@@ -1,0 +1,102 @@
+#ifndef DECLARATIVESIZEPOLICYEXTENSION_H
+#define DECLARATIVESIZEPOLICYEXTENSION_H
+
+#include <QObject>
+
+class DeclarativeSizePolicy : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(ControlType controlType READ controlType WRITE setControlType NOTIFY controlTypeChanged)
+
+    Q_PROPERTY(Policy horizontalPolicy READ horizontalPolicy WRITE setHorizontalPolicy NOTIFY horizontalPolicyChanged)
+    Q_PROPERTY(Policy verticalPolicy READ verticalPolicy WRITE setVerticalPolicy NOTIFY verticalPolicyChanged)
+
+    Q_PROPERTY(Qt::Orientations expandingDirections READ expandingDirections STORED false NOTIFY expandingDirectionsChanged)
+
+    Q_PROPERTY(bool hasHeightForWidth READ hasHeightForWidth WRITE setHeightForWidth NOTIFY hasHeightForWidthChanged)
+    Q_PROPERTY(bool hasWidthForHeight READ hasWidthForHeight WRITE setWidthForHeight NOTIFY hasWidthForHeightChanged)
+
+    Q_PROPERTY(int horizontalStretch READ horizontalStretch WRITE setHorizontalStretch NOTIFY horizontalStretchChanged)
+    Q_PROPERTY(int verticalStretch READ verticalStretch WRITE setVerticalStretch NOTIFY verticalStretchChanged)
+
+    Q_PROPERTY(bool retainSizeWhenHidden READ retainSizeWhenHidden WRITE setRetainSizeWhenHidden NOTIFY retainSizeWhenHiddenChanged)
+
+public:
+    enum PolicyFlag {
+        GrowFlag = 1,
+        ExpandFlag = 2,
+        ShrinkFlag = 4,
+        IgnoreFlag = 8
+    };
+
+    enum Policy {
+        Fixed = 0,
+        Minimum = GrowFlag,
+        Maximum = ShrinkFlag,
+        Preferred = GrowFlag | ShrinkFlag,
+        MinimumExpanding = GrowFlag | ExpandFlag,
+        Expanding = GrowFlag | ShrinkFlag | ExpandFlag,
+        Ignored = ShrinkFlag | GrowFlag | IgnoreFlag
+    };
+    Q_ENUM(Policy)
+
+    enum ControlType {
+        DefaultType      = 0x00000001,
+        ButtonBox        = 0x00000002,
+        CheckBox         = 0x00000004,
+        ComboBox         = 0x00000008,
+        Frame            = 0x00000010,
+        GroupBox         = 0x00000020,
+        Label            = 0x00000040,
+        Line             = 0x00000080,
+        LineEdit         = 0x00000100,
+        PushButton       = 0x00000200,
+        RadioButton      = 0x00000400,
+        Slider           = 0x00000800,
+        SpinBox          = 0x00001000,
+        TabWidget        = 0x00002000,
+        ToolButton       = 0x00004000
+    };
+    Q_ENUM(ControlType)
+    Q_DECLARE_FLAGS(ControlTypes, ControlType)
+    Q_FLAG(ControlTypes)
+
+    explicit DeclarativeSizePolicy(QWidget* extendedWidget, QObject* parent);
+
+    ControlType controlType() const;
+    Policy horizontalPolicy() const;
+    Policy verticalPolicy() const;
+    Qt::Orientations expandingDirections() const;
+    bool hasHeightForWidth() const;
+    bool hasWidthForHeight() const;
+    int horizontalStretch() const;
+    int verticalStretch() const;
+    bool retainSizeWhenHidden() const;
+
+public slots:
+    void setControlType(ControlType controlType);
+    void setHorizontalPolicy(Policy horizontalPolicy);
+    void setVerticalPolicy(Policy verticalPolicy);
+    void setHeightForWidth(bool heightForWidth);
+    void setWidthForHeight(bool widthForHeight);
+    void setHorizontalStretch(int horizontalStretch);
+    void setVerticalStretch(int verticalStretch);
+    void setRetainSizeWhenHidden(bool retainSizeWhenHidden);
+
+signals:
+    void controlTypeChanged(ControlType controlType);
+    void horizontalPolicyChanged(Policy horizontalPolicy);
+    void verticalPolicyChanged(Policy verticalPolicy);
+    void expandingDirectionsChanged(Qt::Orientations expandingDirections);
+    void hasHeightForWidthChanged(bool hasHeightForWidth);
+    void hasWidthForHeightChanged(bool hasWidthForHeight);
+    void horizontalStretchChanged(int horizontalStretch);
+    void verticalStretchChanged(int verticalStretch);
+    void retainSizeWhenHiddenChanged(bool retainSizeWhenHidden);
+
+private:
+    QWidget* m_extendedWidget;
+};
+
+#endif // DECLARATIVESIZEPOLICYEXTENSION_H

--- a/src/declarativewidgetextension.cpp
+++ b/src/declarativewidgetextension.cpp
@@ -28,6 +28,7 @@
 #include "declarativewidgetextension.h"
 
 #include "declarativeactionitem_p.h"
+#include "declarativesizepolicy_p.h"
 #include "defaultobjectcontainer_p.h"
 #include "defaultwidgetcontainer.h"
 #include "objectadaptors_p.h"
@@ -94,6 +95,7 @@ class WidgetContainerDelegate : public DefaultObjectContainer
 
 DeclarativeWidgetExtension::DeclarativeWidgetExtension(QObject *parent)
   : DeclarativeObjectExtension(new WidgetContainerDelegate(new DefaultWidgetContainer(qobject_cast<QWidget*>(parent))), parent)
+  , m_sizePolicy(nullptr)
 {
   parent->installEventFilter(this);
 }
@@ -227,6 +229,15 @@ bool DeclarativeWidgetExtension::eventFilter(QObject *watched, QEvent *event)
   }
 
   return false;
+}
+
+DeclarativeSizePolicy *DeclarativeWidgetExtension::sizePolicy()
+{
+  if (!m_sizePolicy) {
+    m_sizePolicy = new DeclarativeSizePolicy(extendedWidget(), this);
+  }
+
+  return m_sizePolicy;
 }
 
 DeclarativeWidgetExtension::DeclarativeWidgetExtension(WidgetContainerInterface *widgetContainer, QObject *parent)

--- a/src/declarativewidgetextension.h
+++ b/src/declarativewidgetextension.h
@@ -33,6 +33,7 @@
 
 #include <QRect>
 
+class DeclarativeSizePolicy;
 class WidgetContainerInterface;
 
 QT_BEGIN_NAMESPACE
@@ -54,6 +55,7 @@ class DeclarativeWidgetExtension : public DeclarativeObjectExtension
   Q_PROPERTY(int height READ height WRITE setHeight NOTIFY sizeChanged)
   Q_PROPERTY(QRect geometry READ geometry WRITE setGeometry NOTIFY geometryChanged)
   Q_PROPERTY(bool visible READ isVisible WRITE setVisible NOTIFY visibleChanged)
+  Q_PROPERTY(DeclarativeSizePolicy *sizePolicy READ sizePolicy CONSTANT)
 
   Q_CLASSINFO("DefaultProperty", "data")
 
@@ -82,6 +84,8 @@ class DeclarativeWidgetExtension : public DeclarativeObjectExtension
 
     bool eventFilter(QObject *watched, QEvent *event);
 
+    DeclarativeSizePolicy *sizePolicy();
+
   protected:
     explicit DeclarativeWidgetExtension(WidgetContainerInterface *widgetContainer, QObject *parent = 0);
 
@@ -90,6 +94,9 @@ class DeclarativeWidgetExtension : public DeclarativeObjectExtension
     void sizeChanged();
     void geometryChanged();
     void visibleChanged(bool visible);
+
+  private:
+    DeclarativeSizePolicy *m_sizePolicy;
 };
 
 #endif // DECLARATIVEWIDGETEXTENSION_H

--- a/src/declarativewidgets_plugin.cpp
+++ b/src/declarativewidgets_plugin.cpp
@@ -51,6 +51,7 @@
 #include "declarativeqmlcontext_p.h"
 #include "declarativequickwidgetextension_p.h"
 #include "declarativeseparator_p.h"
+#include "declarativesizepolicy_p.h"
 #include "declarativespaceritem_p.h"
 #include "declarativestackedlayout_p.h"
 #include "declarativestatusbar_p.h"
@@ -123,6 +124,8 @@ void ExtensionpluginPlugin::registerTypes(const char *uri)
   qmlRegisterUncreatableType<DeclarativeLayoutContentsMargins>(uri, 1, 0, "LayoutContentMargins", "Grouped Property");
   qmlRegisterUncreatableType<QHeaderView>(uri, 1, 0, "HeaderView", "");
   qmlRegisterUncreatableType<QLayout>(uri, 1, 0, "Layout", "For access of SizeConstraint enum");
+  qmlRegisterUncreatableType<QSizePolicy>(uri, 1, 0, "QSizePolicy", "Cannot create QSizePolicy, it is a Q_GADGET");
+  qmlRegisterUncreatableType<DeclarativeSizePolicy>(uri, 1, 0, "SizePolicy", "Cannot create SizePolicy, it wraps QSizePolicy");
 
   // core
   qmlRegisterType<QTimer>(uri, 1, 0, "Timer");

--- a/src/src.pro
+++ b/src/src.pro
@@ -85,7 +85,8 @@ HEADERS = \
     stackedwidgetwidgetcontainer_p.h \
     staticdialogmethodattached_p.h \
     toolbarwidgetcontainer_p.h \
-    widgetcontainerinterface_p.h
+    widgetcontainerinterface_p.h \
+    declarativesizepolicy_p.h
 
 SOURCES = \
     abstractdeclarativeobject.cpp \
@@ -135,4 +136,5 @@ SOURCES = \
     scrollareawidgetcontainer.cpp \
     stackedwidgetwidgetcontainer.cpp \
     staticdialogmethodattached.cpp \
-    toolbarwidgetcontainer.cpp
+    toolbarwidgetcontainer.cpp \
+    declarativesizepolicy.cpp

--- a/tests/auto/layouts/qml/GridLayoutTest.qml
+++ b/tests/auto/layouts/qml/GridLayoutTest.qml
@@ -73,6 +73,10 @@ Widget {
     }
     PushButton {
         text: "+"
+        sizePolicy {
+            horizontalPolicy: SizePolicy.Minimum
+            verticalPolicy: SizePolicy.Minimum
+        }
 
         GridLayout.row: 1
         GridLayout.column: 3
@@ -116,6 +120,10 @@ Widget {
     }
     PushButton {
         text: "Enter"
+        sizePolicy {
+            horizontalPolicy: SizePolicy.Minimum
+            verticalPolicy: SizePolicy.Minimum
+        }
 
         GridLayout.row: 3
         GridLayout.column: 3

--- a/tests/auto/layouts/tst_layouts.cpp
+++ b/tests/auto/layouts/tst_layouts.cpp
@@ -430,8 +430,7 @@ void tst_Layouts::compareWidgets(QWidget *a, QWidget *b)
     QVERIFY2(a != nullptr, "a QWidget is null");
     QVERIFY2(b != nullptr, "b QWidget is null");
 
-    QVERIFY2(a->sizePolicy() == b->sizePolicy(), "Expected size policy to match");
-
+    compareSizePolicy(a->sizePolicy(), b->sizePolicy());
     compareLayouts(a->layout(), b->layout());
     compareGeometry(a->geometry(), b->geometry());
 }
@@ -497,6 +496,7 @@ void tst_Layouts::compareSizePolicy(const QSizePolicy& aPolicy, const QSizePolic
              , qPrintable(QStringLiteral("verticalStretch does not match (%1 != %2")
                           .arg(aPolicy.verticalStretch())
                           .arg(bPolicy.verticalStretch())));
+    // Tests may fail here due to [QTBUG-66747] uic generates incorrect code to set QSizePolicy
     QVERIFY2(aPolicy.controlType() == bPolicy.controlType()
              , qPrintable(QStringLiteral("controlType does not match (%1 != %2")
                           .arg(aPolicy.controlType())


### PR DESCRIPTION
QSizePolicy is a Q_GADGET and exposed by QWidget, but does not have
any Q_PROPERTY declarations to make it useful. This commit wraps
QSizePolicy in a QObject wrapper and overrides the QWidget sizePolicy
property to expose the wrapper. The wrapper object is only created
the first time it is read.

tst_Layouts::gridLayout still fails due to
https://bugreports.qt.io/browse/QTBUG-66747