### PR TITLE
Update minimum required Qt version.

### DIFF
--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -5,15 +5,7 @@ creating QtWidget User Interfaces with QML.
 
 Dependencies
 ============
-DeclarativeWidgets depends features currently in the dev branch. To use
-DeclarativeWidgets you will need to build [qtbase][1] and [qtdeclarative][2]
-from the dev branch. If you wish to use [Qt WebEngine Widgets][3] you will need
-to build [qtwebengine][4] and its dependencies as well.
-
-[1]: https://codereview.qt-project.org/#/admin/projects/qt/qtbase
-[2]: https://codereview.qt-project.org/#/admin/projects/qt/qtdeclarative
-[3]: http://doc.qt.io/qt-5/qtwebenginewidgets-index.html
-[4]: https://codereview.qt-project.org/#/admin/projects/qt/qtwebengine
+DeclarativeWidgets requires Qt 5.11.0 or above.
 
 Building and running
 ====================

--- a/src/src.pro
+++ b/src/src.pro
@@ -2,6 +2,8 @@ TEMPLATE = lib
 TARGET = declarativewidgets
 QT += core-private qml widgets quickwidgets
 
+!versionAtLeast(QT_VERSION, 5.11.0):error("DeclarativeWidgets requires at least Qt version 5.11.0")
+
 qtHaveModule(webenginewidgets) {
     QT += webenginewidgets
 }


### PR DESCRIPTION
It is no longer necessary to build Qt from the dev branch to use
DeclarativeWidgets. The minimum required version is Qt 5.11.0.