### PR TITLE
Remove DECLARATIVE_OBJECT macro

### DIFF
--- a/src/declarativeqmlcontext.cpp
+++ b/src/declarativeqmlcontext.cpp
@@ -70,5 +70,3 @@ void DeclarativeQmlContext::dataAppend(QObject *object)
 
   DeclarativeObjectProxy<DeclarativeContext>::dataAppend(object);
 }
-
-CUSTOM_METAOBJECT(DeclarativeQmlContext, DeclarativeContext)

--- a/src/declarativeqmlcontext_p.h
+++ b/src/declarativeqmlcontext_p.h
@@ -35,8 +35,6 @@
 
 class DeclarativeQmlContext : public DeclarativeObjectProxy<DeclarativeContext>
 {
-  DECLARATIVE_OBJECT
-
   public:
     explicit DeclarativeQmlContext(QObject *parent = 0);
 


### PR DESCRIPTION
The initialisation of the static QMetaObject was causing an exception on
Windows.

We could not remember why the macro was required. The API provided
appears not to be used so we have removed it for the time being.

This fixes test failures in tst_InstantiateTypes and tst_QmlPlugins on
Windows. There are two remaining failures due to a difference in
expected size and known issue with QSizePolicy.

Closes #23 