### PR TITLE
fix(qt6): Add 'margin' property to layouts for compat with Qt 5

### DIFF
--- a/src/declarativeformlayout_p.h
+++ b/src/declarativeformlayout_p.h
@@ -78,6 +78,7 @@ class DeclarativeFormLayoutExtension : public DeclarativeLayoutExtension
   // repeat property declarations, qmlRegisterExtendedType doesn't see the ones from base class
   Q_PROPERTY(QQmlListProperty<QObject> data READ data DESIGNABLE false CONSTANT)
   Q_PROPERTY(DeclarativeLayoutContentsMargins* contentsMargins READ contentsMargins CONSTANT)
+  Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
 
   Q_CLASSINFO("DefaultProperty", "data")
 

--- a/src/declarativegridlayout_p.h
+++ b/src/declarativegridlayout_p.h
@@ -101,6 +101,7 @@ class DeclarativeGridLayoutExtension : public DeclarativeLayoutExtension
   // repeat property declarations, qmlRegisterExtendedType doesn't see the ones from base class
   Q_PROPERTY(QQmlListProperty<QObject> data READ data DESIGNABLE false CONSTANT)
   Q_PROPERTY(DeclarativeLayoutContentsMargins* contentsMargins READ contentsMargins CONSTANT)
+  Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
 
   Q_CLASSINFO("DefaultProperty", "data")
 

--- a/src/declarativehboxlayout_p.h
+++ b/src/declarativehboxlayout_p.h
@@ -55,6 +55,7 @@ class DeclarativeHBoxLayoutExtension : public DeclarativeLayoutExtension
   // repeat property declarations, qmlRegisterExtendedType doesn't see the ones from base class
   Q_PROPERTY(QQmlListProperty<QObject> data READ data DESIGNABLE false CONSTANT)
   Q_PROPERTY(DeclarativeLayoutContentsMargins* contentsMargins READ contentsMargins CONSTANT)
+  Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
 
   Q_CLASSINFO("DefaultProperty", "data")
 

--- a/src/declarativelayoutextension.cpp
+++ b/src/declarativelayoutextension.cpp
@@ -175,6 +175,27 @@ DeclarativeLayoutContentsMargins *DeclarativeLayoutExtension::contentsMargins() 
   return m_contentsMargins;
 }
 
+int DeclarativeLayoutExtension::margin() const
+{
+  // QLayout::margin() was removed in Qt 6
+
+  if (m_contentsMargins->leftMargin() == m_contentsMargins->topMargin() &&
+      m_contentsMargins->leftMargin() == m_contentsMargins->rightMargin() &&
+      m_contentsMargins->leftMargin() == m_contentsMargins->bottomMargin()) {
+    return m_contentsMargins->leftMargin();
+  }
+
+  return -1;
+}
+
+void DeclarativeLayoutExtension::setMargin(int margin)
+{
+  if (margin != this->margin()) {
+    extendedLayout()->setContentsMargins({margin, margin, margin, margin}) ;
+    Q_EMIT marginChanged();
+  }
+}
+
 DeclarativeLayoutExtension::DeclarativeLayoutExtension(LayoutContainerInterface *layoutContainer, QObject *parent)
   : DeclarativeObjectExtension(new LayoutContainerDelegate(layoutContainer), parent)
   , m_contentsMargins(new DeclarativeLayoutContentsMargins(layoutContainer, this))

--- a/src/declarativelayoutextension.h
+++ b/src/declarativelayoutextension.h
@@ -83,9 +83,14 @@ class DeclarativeLayoutExtension : public DeclarativeObjectExtension
   public:
     QLayout *extendedLayout() const;
     DeclarativeLayoutContentsMargins *contentsMargins() const;
+    int margin() const;
+    void setMargin(int);
 
   protected:
     explicit DeclarativeLayoutExtension(LayoutContainerInterface *layoutContainer, QObject *parent = 0);
+
+  Q_SIGNALS:
+    void marginChanged();
 
   private:
     DeclarativeLayoutContentsMargins *m_contentsMargins;

--- a/src/declarativestackedlayout_p.h
+++ b/src/declarativestackedlayout_p.h
@@ -51,6 +51,7 @@ class DeclarativeStackedLayoutExtension : public DeclarativeLayoutExtension
   Q_PROPERTY(QQmlListProperty<QObject> data READ data DESIGNABLE false CONSTANT)
   Q_PROPERTY(DeclarativeLayoutContentsMargins* contentsMargins READ contentsMargins CONSTANT)
   Q_PROPERTY(int count READ count)
+  Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
 
   Q_CLASSINFO("DefaultProperty", "data")
 

--- a/src/declarativevboxlayout_p.h
+++ b/src/declarativevboxlayout_p.h
@@ -56,6 +56,7 @@ class DeclarativeVBoxLayoutExtension : public DeclarativeLayoutExtension
   // repeat property declarations, qmlRegisterExtendedType doesn't see the ones from base class
   Q_PROPERTY(QQmlListProperty<QObject> data READ data DESIGNABLE false CONSTANT)
   Q_PROPERTY(DeclarativeLayoutContentsMargins* contentsMargins READ contentsMargins CONSTANT)
+  Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
 
   Q_CLASSINFO("DefaultProperty", "data")
 


### PR DESCRIPTION
Qt6 doesn't have QLayout::margin property anymore, which breaks our examples. Readded into our extension.